### PR TITLE
Allow empty space to be specified in template.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
         'src/Tile.js',
         'src/Template.js',
         'src/UniformTemplates.js',
+        'src/SmartArrangeTemplates.js',
         'src/Grid.js'
       ]
     },

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -201,7 +201,7 @@
         // ensure that we have at least one column
         numCols = Math.max(1, numCols);
 
-        var template = this.templateFactory.get(numCols, targetTiles);
+        var template = this.templateFactory.get(numCols, targetTiles, this.tiles);
         if (!template) {
             
             // fallback in case the default factory can't generate a good template

--- a/src/SmartArrangeTemplates.js
+++ b/src/SmartArrangeTemplates.js
@@ -1,0 +1,79 @@
+// template provider which returns simple templates with 1x1 tiles
+Tiles.SmartArrangeTemplates = {
+    get: function (numCols, targetTiles, tiles) {
+        var LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+            i, j, iLen, jLen, regExp, d, dx, match, strReplace, tileSegmentStr, strBuilder, templateArr, matchIndex,
+            DEFAULT_TILE_SIZE = { x: 1, y: 1 };
+
+        //helper function to build new line of template.
+        var buildTemplateLineSegment = function (n) {
+            strBuilder = [];
+            for (i = 0; i < n; i++) {
+                strBuilder.push('.');
+            }
+            strBuilder.push('*');
+            return strBuilder.join('');
+        };
+
+        //Fall back to uniform templates factory if tiles is null or empty.
+        if (!tiles || tiles.length === 0) {
+            return Tiles.UniformTemplates.get(numCols, targetTiles);
+        }
+
+        //Initialize template string.
+        var templateString = buildTemplateLineSegment(numCols);
+
+        for (var index = 0, tile; tile = tiles[index]; index++) {
+
+            d = tile.id.size || DEFAULT_TILE_SIZE;
+            dx = numCols < d.x ? numCols : d.x;
+
+            //Regular Expression use to see if current tile can fit within the current template.
+            regExp = new RegExp('(\\.{' + dx + '}.{' + (numCols - dx + 1) + '}){' + d.y + '}', 'g');
+
+            match = null;
+            //Append to template until we can fit the current tile.
+            while (!(match = templateString.match(regExp))) {
+                templateString += buildTemplateLineSegment(numCols);
+            }
+
+            //Once we find the section of the template that can fit the tile, insert the tile into template.
+            strReplace = match[0].split('');
+            tileSegmentStr = '';
+            strBuilder = [];
+            
+            //Building the tile horizontal segment.
+            for (i = 0; i < dx; i++) {
+                strBuilder.push(LABELS[index % 26]);
+            }
+            tileSegmentStr = strBuilder.join('');
+
+            //Replace the empty space in template with tile segments.
+            for (i = 0, iLen = strReplace.length; i < iLen; i += numCols + 1) {
+                for (j = 0, jLen = tileSegmentStr.length; j < jLen; j++) {
+                    strReplace[i + j] = tileSegmentStr[j];
+                }
+            }
+
+            //Rebuilding the template
+            templateArr = [];
+            matchIndex = templateString.indexOf(match[0]);
+            
+            //Assure that no following small tiles can fit within this space to avoid tiles to be out of order.
+            templateArr.push(templateString.substring(0, matchIndex).replace(/\./g, '~'));
+            
+            templateArr.push(strReplace.join(''));
+            templateArr.push(templateString.substring(matchIndex + match[0].length));
+
+            templateString = templateArr.join('');
+        }
+        templateString = templateString.replace(/\*/ig, '').replace(/(\.)/ig, '~');
+        //Convert template into json object.
+        var templateJson = [];
+        for (i = 0, iLen = templateString.length; i < iLen; i += numCols) {
+            templateJson.push(templateString.slice(i, i + numCols));
+        }
+
+        return Tiles.Template.fromJSON(templateJson);
+    }
+};

--- a/src/Template.js
+++ b/src/Template.js
@@ -70,7 +70,7 @@
             numRows = cells.length,
             numCols = numRows === 0 ? 0 : cells[0].length,
             cell, height, width, x, y, rectX, rectY;
-
+        
         // make a copy of the cells that we can modify
         cells = cells.slice();
         for (y = 0; y < numRows; y++) {
@@ -112,8 +112,10 @@
                     }
                 }
 
-                // add the rect
-                rects.push(new Rectangle(x, y, width, height));
+                // add the rect if not empty space padding
+                if (cell !== Tiles.Template.CELL_PADDING) {
+                    rects.push(new Rectangle(x, y, width, height));
+                }
             }
         }
 
@@ -177,21 +179,20 @@
             rows = [],
             i, len, rect, x, y, label;
 
-        // fill in single tiles for each cell
+        // fill entire grid with cell paddings
         for (y = 0; y < this.numRows; y++) {
             rows[y] = [];
             for (x = 0; x < this.numCols; x++) {
-                rows[y][x] = Tiles.Template.SINGLE_CELL;
+                rows[y][x] = Tiles.Template.CELL_PADDING;
             }
         }
 
         // now fill in bigger tiles
         for (i = 0, len = this.rects.length; i < len; i++) {
             rect = this.rects[i];
-            if (rect.width > 1 || rect.height > 1) {
 
                 // mark the tile position with a label
-                label = LABELS[labelIndex];
+                label = (rect.width === 1 && rect.height === 1) ? Tiles.Template.SINGLE_CELL : LABELS[labelIndex];
                 for(y = 0; y < rect.height; y++) {
                     for(x = 0; x < rect.width; x++) {
                         rows[rect.y + y][rect.x + x] = label;
@@ -200,7 +201,6 @@
 
                 // advance the label index
                 labelIndex = (labelIndex + 1) % NUM_LABELS;
-            }
         }
 
         // turn the rows into strings
@@ -213,5 +213,6 @@
     
     // period used to designate a single 1x1 cell tile
     Tiles.Template.SINGLE_CELL = '.';
+    Tiles.Template.CELL_PADDING = '~';
 
 })(jQuery);


### PR DESCRIPTION
Allow user to specify empty spaces with '~' instead of single-cell tiles
('.') in template to fill needed empty spaces. See
http://jsfiddle.net/iNeedFat/vA4Nc/1/ to see where this would be
necessary.

Sorry, I'm not sure why github sees the entire changed file to be different.
